### PR TITLE
Task/custom prop sanitization

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+	"java.configuration.updateBuildConfiguration": "automatic"
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,68 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build and Development Commands
+
+```bash
+# Build the module
+./gradlew build
+
+# Deploy to gateway (configure hostGateway in gradle.properties)
+./gradlew deployModl
+```
+
+## Project Architecture
+
+This is an **Ignition Module** for Inductive Automation's Ignition platform, built using the Ignition SDK. The module enhances the Designer with quality-of-life tools and utilities.
+
+### Module Structure
+- **Gateway scope** (`gateway/`): Server-side functionality including RPC handlers for CSS file reading
+- **Designer scope** (`designer/`): Main functionality with toolbar actions and utilities
+- **Client scope** (`client/`): Vision client components and hooks  
+- **Common scope** (`common/`): Shared interfaces and constants
+
+### Key Components
+
+#### Toolbar Actions (`designer/src/main/java/org/dev/arai/designerpp/actions/`)
+- `CSSVariableViewerAction`: CSS variable browser with visual color preview
+- `NoteAction`: Project-scoped notepad with persistent storage
+- `SanitizeCustomPropsAction`: Custom property management utilities
+- `SetParamsAction` & `CleanParamsAction`: Component parameter utilities
+
+#### RPC Communication
+- `DesignerPlusPlusRPC` (common): Defines client-gateway communication interface
+- `DesignerPlusPlusRPCHandler` (gateway): Server-side RPC implementation for CSS file operations
+
+#### Utilities
+- `EditorUtils`: Designer integration helpers
+- `ParseColor`: CSS color parsing and visual preview generation
+- `ProjectBrowserStateManager`: Sepasoft compatibility for preserving tree state
+- `CSSFileReader`: Gateway-side CSS theme file processing
+
+### Configuration
+
+Module configuration is in `build.gradle.kts`:
+- Uses Ignition SDK plugin (`io.ia.sdk.modl`)
+- Requires Ignition 8.1.20+
+- Depends on Perspective module for designer features
+- Hooks are registered for each scope (Gateway, Client, Designer)
+
+Deployment configuration in `gradle.properties`:
+- `hostGateway`: Target gateway URL for deployModl task
+- `signModule`: Module signing flag (requires certificate)
+- `version`: Module version for build
+
+### Dependencies
+
+The module uses:
+- Ignition SDK 8.1.20, found at [Ignition SDK](https://files.inductiveautomation.com/sdk/javadoc/ignition81/8.1.47/index.html)
+- Perspective module dependency (designer scope)
+- Standard Java 11+ libraries
+- No external third-party dependencies
+
+### Module Features
+
+1. **CSS Variable Viewer**: Reads Perspective theme CSS files from gateway, parses variables, displays in organized UI with color previews
+2. **Designer NotePad**: Project-scoped persistent note storage using JSON files in designer resources
+3. **Project Browser State Manager**: Detects Sepasoft modules and preserves tree expansion state during saves

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,8 @@ ignitionModule {
         ":gateway" to "G"
     ))
     moduleDependencies.set(mapOf<String, String>())
+    // This module depends on the Perspective module for designer features
+    moduleDependencies.put("com.inductiveautomation.perspective", "D")
     moduleDependencySpecs { }
     hooks.putAll(mapOf(
         "org.dev.arai.designerpp.gateway.DesignerPlusPlusGatewayHook" to "G",

--- a/common/src/main/java/org/dev/arai/designerpp/common/DesignerPlusPlusConstants.java
+++ b/common/src/main/java/org/dev/arai/designerpp/common/DesignerPlusPlusConstants.java
@@ -15,4 +15,5 @@ public class DesignerPlusPlusConstants {
     public static final List<String> IGNITION_DEFAULT_THEMES = List.of(
         "dark", "dark-cool", "dark-warm", "light", "light-cool", "light-warm", "sepasoft-light", "sepasoft-dark"
     );
+    public static final String PERSPECTIVE_MODULE_ID = "com.inductiveautomation.perspective";
 }

--- a/designer/build.gradle.kts
+++ b/designer/build.gradle.kts
@@ -14,4 +14,5 @@ dependencies {
     compileOnly(project(":common"))
 
     // add designer scoped dependencies here
+    implementation("com.inductiveautomation.ignitionsdk:perspective-designer:${rootProject.extra["sdk_version"]}")
 }

--- a/designer/src/main/java/org/dev/arai/designerpp/actions/CleanParamsAction.java
+++ b/designer/src/main/java/org/dev/arai/designerpp/actions/CleanParamsAction.java
@@ -1,0 +1,31 @@
+package org.dev.arai.designerpp.actions;
+
+import org.dev.arai.designerpp.common.DesignerPlusPlusConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.inductiveautomation.ignition.client.gateway_interface.ModuleRPCFactory;
+import com.inductiveautomation.ignition.client.util.action.BaseAction;
+import com.inductiveautomation.ignition.designer.model.DesignerContext;
+
+import static com.inductiveautomation.ignition.common.BundleUtil.i18n;
+
+import javax.swing.Icon;
+
+public class CleanParamsAction extends BaseAction {
+	private static final Logger logger = LoggerFactory.getLogger(DesignerPlusPlusConstants.MODULE_ID + ".CleanParamsAction");
+	private final DesignerContext context;
+
+
+	public CleanParamsAction(DesignerContext context, Icon icon) {
+		super(i18n("designerpp.Action.ClearParams.Name"), icon);
+		this.context = context;
+		putValue(SHORT_DESCRIPTION, i18n("designerpp.Action.ClearParams.Description"));
+		logger.debug("Clean Parameters Action initialized");
+	}
+
+	@Override
+	public void actionPerformed(java.awt.event.ActionEvent e) {
+		logger.debug("Clean Parameters Action performed");
+	}
+}

--- a/designer/src/main/java/org/dev/arai/designerpp/actions/CleanParamsAction.java
+++ b/designer/src/main/java/org/dev/arai/designerpp/actions/CleanParamsAction.java
@@ -4,7 +4,6 @@ import org.dev.arai.designerpp.common.DesignerPlusPlusConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.inductiveautomation.ignition.client.gateway_interface.ModuleRPCFactory;
 import com.inductiveautomation.ignition.client.util.action.BaseAction;
 import com.inductiveautomation.ignition.designer.model.DesignerContext;
 

--- a/designer/src/main/java/org/dev/arai/designerpp/actions/SanitizeCustomPropsAction.java
+++ b/designer/src/main/java/org/dev/arai/designerpp/actions/SanitizeCustomPropsAction.java
@@ -1,0 +1,54 @@
+package org.dev.arai.designerpp.actions;
+
+import org.dev.arai.designerpp.common.DesignerPlusPlusConstants;
+import org.dev.arai.designerpp.utils.EditorUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.inductiveautomation.ignition.client.gateway_interface.ModuleRPCFactory;
+import com.inductiveautomation.ignition.client.util.action.BaseAction;
+import com.inductiveautomation.ignition.common.gson.JsonObject;
+import com.inductiveautomation.ignition.designer.model.DesignerContext;
+import com.inductiveautomation.ignition.designer.tabbedworkspace.TabbedResourceWorkspace;
+import com.inductiveautomation.perspective.common.api.PropertyKey;
+import com.inductiveautomation.perspective.common.config.BindingConfig;
+import com.inductiveautomation.perspective.common.config.PropertyConfig;
+import com.inductiveautomation.perspective.common.config.PropertyConfigCollection;
+import com.inductiveautomation.perspective.common.config.ViewConfig;
+import com.inductiveautomation.perspective.designer.workspace.ViewResourceEditor;
+
+import static com.inductiveautomation.ignition.common.BundleUtil.i18n;
+
+import java.util.List;
+
+import javax.swing.Icon;
+
+public class SanitizeCustomPropsAction extends BaseAction {
+	private static final Logger logger = LoggerFactory.getLogger(DesignerPlusPlusConstants.MODULE_ID + ".SanitizeCustomPropsAction");
+	private final DesignerContext context;
+	private EditorUtils editorUtils;
+
+
+	public SanitizeCustomPropsAction(DesignerContext context, Icon icon) {
+		super(i18n("designerpp.Action.SanitizeCustomProps.Name"), icon);
+		this.context = context;
+		this.editorUtils = new EditorUtils(context);
+		putValue(SHORT_DESCRIPTION, i18n("designerpp.Action.SanitizeCustomProps.Description"));
+		logger.debug("Sanitize Custom Props Action initialized");
+	}
+
+	@Override
+	public void actionPerformed(java.awt.event.ActionEvent e) {
+		logger.debug("Sanitize Custom Props Action performed");
+		TabbedResourceWorkspace workspace = editorUtils.getWorkspace();
+		ViewResourceEditor currentViewResourceEditor = editorUtils.getCurrentSelectedViewResourceEditor(workspace);
+		currentViewResourceEditor.getWorkspace().commitAll();
+		ViewConfig currentViewConfig = editorUtils.getCurrentSelectedViewConfig(currentViewResourceEditor);
+		PropertyConfigCollection customPropsCollection = editorUtils.getCurrentSelectedPropertyConfigCollection(currentViewConfig);
+		List<String> customPropsWithBindings = editorUtils.getCustomPropNamesWithBindings(customPropsCollection);
+		editorUtils.setPrivate(customPropsWithBindings, customPropsCollection);
+		currentViewResourceEditor.getWorkspace().getPropertyEditor().commitEdit();
+		currentViewResourceEditor.refresh();
+		logger.info("Custom properties with bindings were set to private and non-persistent, be sure to save your designer before committing.");
+	}
+}

--- a/designer/src/main/java/org/dev/arai/designerpp/actions/SanitizeCustomPropsAction.java
+++ b/designer/src/main/java/org/dev/arai/designerpp/actions/SanitizeCustomPropsAction.java
@@ -5,14 +5,9 @@ import org.dev.arai.designerpp.utils.EditorUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.inductiveautomation.ignition.client.gateway_interface.ModuleRPCFactory;
 import com.inductiveautomation.ignition.client.util.action.BaseAction;
-import com.inductiveautomation.ignition.common.gson.JsonObject;
 import com.inductiveautomation.ignition.designer.model.DesignerContext;
 import com.inductiveautomation.ignition.designer.tabbedworkspace.TabbedResourceWorkspace;
-import com.inductiveautomation.perspective.common.api.PropertyKey;
-import com.inductiveautomation.perspective.common.config.BindingConfig;
-import com.inductiveautomation.perspective.common.config.PropertyConfig;
 import com.inductiveautomation.perspective.common.config.PropertyConfigCollection;
 import com.inductiveautomation.perspective.common.config.ViewConfig;
 import com.inductiveautomation.perspective.designer.workspace.ViewResourceEditor;

--- a/designer/src/main/java/org/dev/arai/designerpp/actions/SetParamsAction.java
+++ b/designer/src/main/java/org/dev/arai/designerpp/actions/SetParamsAction.java
@@ -4,7 +4,6 @@ import org.dev.arai.designerpp.common.DesignerPlusPlusConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.inductiveautomation.ignition.client.gateway_interface.ModuleRPCFactory;
 import com.inductiveautomation.ignition.client.util.action.BaseAction;
 import com.inductiveautomation.ignition.designer.model.DesignerContext;
 

--- a/designer/src/main/java/org/dev/arai/designerpp/actions/SetParamsAction.java
+++ b/designer/src/main/java/org/dev/arai/designerpp/actions/SetParamsAction.java
@@ -1,0 +1,32 @@
+package org.dev.arai.designerpp.actions;
+
+import org.dev.arai.designerpp.common.DesignerPlusPlusConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.inductiveautomation.ignition.client.gateway_interface.ModuleRPCFactory;
+import com.inductiveautomation.ignition.client.util.action.BaseAction;
+import com.inductiveautomation.ignition.designer.model.DesignerContext;
+
+import static com.inductiveautomation.ignition.common.BundleUtil.i18n;
+
+import javax.swing.Icon;
+
+public class SetParamsAction extends BaseAction {
+	private static final Logger logger = LoggerFactory.getLogger(DesignerPlusPlusConstants.MODULE_ID + ".SetParamsAction");
+	private final DesignerContext context;
+
+
+	public SetParamsAction(DesignerContext context, Icon icon) {
+		super(i18n("designerpp.Action.SetParams.Name"), icon);
+		this.context = context;
+		putValue(SHORT_DESCRIPTION, i18n("designerpp.Action.SetParams.Description"));
+		logger.debug("Set Parameters Action initialized");
+	}
+
+	@Override
+	public void actionPerformed(java.awt.event.ActionEvent e) {
+		logger.debug("Set Parameters Action performed");
+		System.out.println("Set Parameters Action performed");
+	}
+}

--- a/designer/src/main/java/org/dev/arai/designerpp/designer/DesignerPlusPlusDesignerHook.java
+++ b/designer/src/main/java/org/dev/arai/designerpp/designer/DesignerPlusPlusDesignerHook.java
@@ -56,11 +56,14 @@ public class DesignerPlusPlusDesignerHook extends AbstractDesignerModuleHook {
 
         String userHome = System.getProperty("user.home");
         File noteFile = new File(userHome, "notePad.json");
-        // OR use temp directory: File noteFile = new File(System.getProperty("java.io.tmpdir"), "notePad.json");
         
         if (!noteFile.exists()) {
-            noteFile.createNewFile();
-            logger.info("Created notePad.json file at: " + noteFile.getAbsolutePath());
+            try {
+                noteFile.createNewFile();
+                logger.info("Created notePad.json file at: " + noteFile.getAbsolutePath());
+            } catch (Exception e) {
+                logger.error("Error creating notePad.json file: " + e.getMessage());
+            }
         }
     }
 
@@ -96,10 +99,11 @@ public class DesignerPlusPlusDesignerHook extends AbstractDesignerModuleHook {
             VectorIcons.getInteractive("property-transient")
         );
 
-        toolbar.addButton(cssAction);
-        toolbar.addButton(cleanParams);
         toolbar.addButton(setParams);
+        toolbar.addButton(cleanParams);
         toolbar.addButton(sanitizeCustomProps);
+        toolbar.addSeparator();
+        toolbar.addButton(cssAction);
         toolbar.addButton(noteAction);
 
         toolbars.add(toolbar);

--- a/designer/src/main/java/org/dev/arai/designerpp/designer/DesignerPlusPlusDesignerHook.java
+++ b/designer/src/main/java/org/dev/arai/designerpp/designer/DesignerPlusPlusDesignerHook.java
@@ -99,8 +99,8 @@ public class DesignerPlusPlusDesignerHook extends AbstractDesignerModuleHook {
             VectorIcons.getInteractive("property-transient")
         );
 
-        toolbar.addButton(setParams);
-        toolbar.addButton(cleanParams);
+        // toolbar.addButton(setParams);
+        // toolbar.addButton(cleanParams);
         toolbar.addButton(sanitizeCustomProps);
         toolbar.addSeparator();
         toolbar.addButton(cssAction);

--- a/designer/src/main/java/org/dev/arai/designerpp/designer/DesignerPlusPlusDesignerHook.java
+++ b/designer/src/main/java/org/dev/arai/designerpp/designer/DesignerPlusPlusDesignerHook.java
@@ -1,13 +1,17 @@
 package org.dev.arai.designerpp.designer;
 
 import org.dev.arai.designerpp.actions.CSSVariableViewerAction;
+import org.dev.arai.designerpp.actions.CleanParamsAction;
 import org.dev.arai.designerpp.actions.NoteAction;
+import org.dev.arai.designerpp.actions.SanitizeCustomPropsAction;
+import org.dev.arai.designerpp.actions.SetParamsAction;
 import org.dev.arai.designerpp.common.DesignerPlusPlusConstants;
 import org.dev.arai.designerpp.utils.ProjectBrowserStateManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -38,17 +42,26 @@ public class DesignerPlusPlusDesignerHook extends AbstractDesignerModuleHook {
 
     /**
      * Default constructor for the CSSVariableViewerDesignerHook.
+     * Initializes the designer context and perspective module.
+     * @param context The DesignerContext instance for this module.
+     * @param activationState The LicenseState for the module.
      */
     @Override
     public void startup(DesignerContext context, LicenseState activationState) throws Exception {
         logger.debug("Designer++ Designer Hook started");
-        BundleUtil.get().addBundle("designerpp", this.getClass(), "designer");
+        
         DesignerPlusPlusDesignerHook.context = context;
         browserStateManager = new ProjectBrowserStateManager(context);
-        File noteFile = new File("notePad.json");
+
+        BundleUtil.get().addBundle("designerpp", this.getClass(), "designer");
+
+        String userHome = System.getProperty("user.home");
+        File noteFile = new File(userHome, "notePad.json");
+        // OR use temp directory: File noteFile = new File(System.getProperty("java.io.tmpdir"), "notePad.json");
+        
         if (!noteFile.exists()) {
             noteFile.createNewFile();
-            logger.info("Created notePad.json file in /Applications/Designer Launcher.app/Contents/Resources");
+            logger.info("Created notePad.json file at: " + noteFile.getAbsolutePath());
         }
     }
 
@@ -71,8 +84,23 @@ public class DesignerPlusPlusDesignerHook extends AbstractDesignerModuleHook {
             context,
             VectorIcons.getInteractive("file-text")
         );
+        CleanParamsAction cleanParams = new CleanParamsAction(
+            context,
+            VectorIcons.getInteractive("clear-erase")
+        );
+        SetParamsAction setParams = new SetParamsAction(
+            context,
+            VectorIcons.getInteractive("set-prop")
+        );
+        SanitizeCustomPropsAction sanitizeCustomProps = new SanitizeCustomPropsAction(
+            context,
+            VectorIcons.getInteractive("property-transient")
+        );
 
         toolbar.addButton(cssAction);
+        toolbar.addButton(cleanParams);
+        toolbar.addButton(setParams);
+        toolbar.addButton(sanitizeCustomProps);
         toolbar.addButton(noteAction);
 
         toolbars.add(toolbar);

--- a/designer/src/main/java/org/dev/arai/designerpp/designer/DesignerPlusPlusDesignerHook.java
+++ b/designer/src/main/java/org/dev/arai/designerpp/designer/DesignerPlusPlusDesignerHook.java
@@ -11,7 +11,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;

--- a/designer/src/main/java/org/dev/arai/designerpp/designer/DesignerPlusPlusDesignerHook.java
+++ b/designer/src/main/java/org/dev/arai/designerpp/designer/DesignerPlusPlusDesignerHook.java
@@ -48,11 +48,11 @@ public class DesignerPlusPlusDesignerHook extends AbstractDesignerModuleHook {
     @Override
     public void startup(DesignerContext context, LicenseState activationState) throws Exception {
         logger.debug("Designer++ Designer Hook started");
+        BundleUtil.get().addBundle("designerpp", this.getClass(), "designer");
         
         DesignerPlusPlusDesignerHook.context = context;
         browserStateManager = new ProjectBrowserStateManager(context);
 
-        BundleUtil.get().addBundle("designerpp", this.getClass(), "designer");
 
         String userHome = System.getProperty("user.home");
         File noteFile = new File(userHome, "notePad.json");

--- a/designer/src/main/java/org/dev/arai/designerpp/utils/EditorUtils.java
+++ b/designer/src/main/java/org/dev/arai/designerpp/utils/EditorUtils.java
@@ -1,0 +1,181 @@
+package org.dev.arai.designerpp.utils;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.dev.arai.designerpp.common.DesignerPlusPlusConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.inductiveautomation.ignition.common.gson.JsonArray;
+import com.inductiveautomation.ignition.common.gson.JsonObject;
+import com.inductiveautomation.ignition.common.gson.JsonPrimitive;
+import com.inductiveautomation.ignition.designer.model.DesignerContext;
+import com.inductiveautomation.ignition.designer.tabbedworkspace.ResourceEditor;
+import com.inductiveautomation.ignition.designer.tabbedworkspace.TabbedResourceWorkspace;
+import com.inductiveautomation.perspective.common.api.PropertyKey;
+import com.inductiveautomation.perspective.common.config.PropertyConfigCollection;
+import com.inductiveautomation.perspective.common.config.ViewConfig;
+import com.inductiveautomation.perspective.designer.DesignerHook;
+import com.inductiveautomation.perspective.designer.workspace.ViewResourceEditor;
+import com.teamdev.jxbrowser.js.Json;
+/**
+ * EditorUtils provides utility methods for interacting with the editor workspace in the Ignition Designer.
+ * It allows retrieval of the workspace, editors, and selected editor using reflection.
+ */
+public class EditorUtils {
+	private final static Logger logger = LoggerFactory.getLogger(DesignerPlusPlusConstants.MODULE_ID + ".EditorUtils");
+	private final DesignerContext context;
+	private final DesignerHook perspective;
+
+	public EditorUtils(DesignerContext context) {
+		this.context = context;
+		this.perspective = (DesignerHook) context.getModule(DesignerPlusPlusConstants.PERSPECTIVE_MODULE_ID);
+	}
+
+	/**
+	 * Retrieves the workspace object from the perspective module.
+	 * Falls back to reflection if direct casting fails.
+	 * 
+	 * @return The workspace object, or null if it could not be retrieved.
+	 */
+	public TabbedResourceWorkspace getWorkspace() {
+		return perspective.getWorkspace();
+	}
+
+	/**
+	 * Retrieves the editors from the workspace.
+	 * 
+	 * @param workspace The workspace object from which to retrieve editors.
+	 * @return The editors object, or null if it could not be retrieved.
+	 */
+	public Collection<ResourceEditor> getEditors(TabbedResourceWorkspace workspace) {
+		if (workspace != null) {
+			return workspace.getEditors();
+		}
+		return null;
+	}
+
+	/**
+	 * Retrieves the selected editor from the workspace.
+	 * 
+	 * @param workspace The workspace object from which to retrieve the selected editor.
+	 * @return The selected editor object, or null if it could not be retrieved.
+	 */
+	public ResourceEditor<?> getSelectedEditor(TabbedResourceWorkspace workspace) {
+		if (workspace != null) {
+			return workspace.getSelectedEditor();
+		}
+		return null;
+	}
+
+	/**
+	 * Convenience method to get the current selected editor directly.
+	 * 
+	 * @return The currently selected editor, or null if not available.
+	 */
+	public ResourceEditor<?> getCurrentSelectedEditor(TabbedResourceWorkspace workspace) {
+		if (workspace != null) {
+			return getSelectedEditor(workspace);
+		}
+		return null;
+	}
+
+	/**
+	 * Convenience method to get all editors directly.
+	 * 
+	 * @return The editors object, or null if not available.
+	 */
+	public Collection<ResourceEditor> getAllEditors() {
+		TabbedResourceWorkspace workspace = getWorkspace();
+		if (workspace != null) {
+			return getEditors(workspace);
+		}
+		return null;
+	}
+
+	/**
+	 * Convenience method to get ViewResourceEditor from the current selected editor
+	 * @return The ViewResourceEditor object, or null if not available.
+	 */
+	public ViewResourceEditor getCurrentSelectedViewResourceEditor(TabbedResourceWorkspace currentWorkspace) {
+		ResourceEditor<?> selectedEditor = getCurrentSelectedEditor(currentWorkspace);
+		if (selectedEditor instanceof ViewResourceEditor) {
+			return (ViewResourceEditor) selectedEditor;
+		}
+		return null;
+	}
+
+	/**
+	 * Convenience method to get the ViewConfig from the current selected editor.
+	 * 
+	 * @return The ViewConfig object, or null if not available.
+	 */
+	public ViewConfig getCurrentSelectedViewConfig(ViewResourceEditor currentViewResourceEditor) {
+		if (currentViewResourceEditor != null) {
+			return currentViewResourceEditor.getViewConfig();
+		}
+		return null;
+	}
+
+	/**
+	 * Convenience method to get the PropertyConfigCollection from the current selected ViewConfig.
+	 * 
+	 * @return The PropertyConfigCollection object, or null if not available.
+	 */
+	public PropertyConfigCollection getCurrentSelectedPropertyConfigCollection(ViewConfig currentViewConfig) {
+		if (currentViewConfig != null) {
+			return currentViewConfig.propConfig;
+		}
+		return null;
+	}
+
+	/**
+	 * Convenience method to get the current custom properties JSON object from the current selected ViewConfig.
+	 * 
+	 * @return The JSON object, or null if not available.
+	 */
+	public JsonObject getCurrentSelectedCustomProperties(ViewConfig currentViewConfig) {
+		if (currentViewConfig != null) {
+			JsonObject customProperties = currentViewConfig.custom;
+			if (customProperties != null) {
+				return customProperties;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Convenience method to get a list of custom property names from the current
+	 * selected ViewConfig that have enabled bindings.
+	 *
+	 * @param currentViewConfig The current ViewConfig.
+	 * @return A list of custom property names with bindings, or an empty list if none.
+	 */
+	public List<String> getCustomPropNamesWithBindings(PropertyConfigCollection propConfigs) {
+		if (propConfigs != null) {
+			return propConfigs.stream()
+					.filter(entry -> entry.getValue().hasEnabledBinding())
+					.filter(entry -> !propConfigs.isSystem(entry.getKey()))
+					.map(entry -> entry.getKey().toString())
+					.collect(Collectors.toList());
+		}
+		return List.of();
+	}
+
+	/**
+	 * Sets the properties as private and also sets the persistence flag to false.
+	 * @param customProps The JSON object containing custom properties.
+	 * @param propertyConfigCollection The PropertyConfigCollection to set the properties on.
+	 */
+	public void setPrivate(List<String> customProps, PropertyConfigCollection propertyConfigCollection) {
+		if (customProps != null && propertyConfigCollection != null) {
+			for (String key : customProps) {
+				propertyConfigCollection.setPrivate(key);
+			}
+		}
+	}
+
+}

--- a/designer/src/main/java/org/dev/arai/designerpp/utils/EditorUtils.java
+++ b/designer/src/main/java/org/dev/arai/designerpp/utils/EditorUtils.java
@@ -1,7 +1,6 @@
 package org.dev.arai.designerpp.utils;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -9,18 +8,14 @@ import org.dev.arai.designerpp.common.DesignerPlusPlusConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.inductiveautomation.ignition.common.gson.JsonArray;
 import com.inductiveautomation.ignition.common.gson.JsonObject;
-import com.inductiveautomation.ignition.common.gson.JsonPrimitive;
 import com.inductiveautomation.ignition.designer.model.DesignerContext;
 import com.inductiveautomation.ignition.designer.tabbedworkspace.ResourceEditor;
 import com.inductiveautomation.ignition.designer.tabbedworkspace.TabbedResourceWorkspace;
-import com.inductiveautomation.perspective.common.api.PropertyKey;
 import com.inductiveautomation.perspective.common.config.PropertyConfigCollection;
 import com.inductiveautomation.perspective.common.config.ViewConfig;
 import com.inductiveautomation.perspective.designer.DesignerHook;
 import com.inductiveautomation.perspective.designer.workspace.ViewResourceEditor;
-import com.teamdev.jxbrowser.js.Json;
 /**
  * EditorUtils provides utility methods for interacting with the editor workspace in the Ignition Designer.
  * It allows retrieval of the workspace, editors, and selected editor using reflection.

--- a/designer/src/main/resources/org/dev/arai/designerpp/designer/designer.properties
+++ b/designer/src/main/resources/org/dev/arai/designerpp/designer/designer.properties
@@ -6,3 +6,12 @@ Action.CSSVariableViewer.Description=View and copy CSS variables
 
 Action.NotePad.Name=NotePad
 Action.NotePad.Description=Opens a simple text editor for quick notes
+
+Action.ClearParams.Name=Clear Parameters
+Action.ClearParams.Description=Clears all view params and saves them to dev-params.json
+
+Action.SetParams.Name=Set Parameters
+Action.SetParams.Description=Sets view params from dev-params.json
+
+Action.SanitizeCustomProps.Name=Sanitize Custom Properties
+Action.SanitizeCustomProps.Description=Sanitizes custom properties in the current view by changing persistence and access mode


### PR DESCRIPTION
- Added ability to set custom props (with bindings) to non-persistent and private.
- Fixed 8.3 designer launcher bug with read-only file system by creating notepad file in the users home directory